### PR TITLE
Bump to 0.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,12 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "CubedSphere"
 uuid = "7445602f-e544-4518-8976-18f8e8ae6cdb"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 TaylorSeries = "6aa5eb33-94cf-58f4-a9d0-e4b2c4fc25ea"
 
 [compat]
-TaylorSeries = "0.10 - 0.18"
+TaylorSeries = "0.10 - 0.19"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
https://github.com/JuliaDiff/TaylorSeries.jl/pull/345 added support to a newer version of IntervalArithmetics. This is needed to support recent versions of Makie.

https://github.com/JuliaDiff/TaylorSeries.jl/pull/345 bumps the version of TaylorSeries to 0.19, and this commit expands compat for that.

CubedSphere.jl does not use IntervalArithmetics, so it is still compatible with 0.19.

This should fix the warnings with `IntervalBox` not being defined.



